### PR TITLE
Add Caltrans road conditions feed to detect highway closures

### DIFF
--- a/internal/clients/caltrans/road_conditions.go
+++ b/internal/clients/caltrans/road_conditions.go
@@ -1,0 +1,265 @@
+package caltrans
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// RoadConditionType represents the type of road condition
+type RoadConditionType int
+
+const (
+	CONDITION_CLOSURE      RoadConditionType = iota // Full road closure
+	CONDITION_CHAIN        // Chain control requirement
+	CONDITION_RESTRICTION  // Traffic restriction (1-way, etc.)
+	CONDITION_INFO         // Informational message
+)
+
+// RoadCondition represents a parsed condition from roads.dot.ca.gov
+type RoadCondition struct {
+	Highway     string            // Highway number, e.g., "4"
+	Type        RoadConditionType // Type of condition
+	Description string            // Full condition text
+	Area        string            // Area designation, e.g., "CENTRAL CALIFORNIA AREA"
+	Reason      string            // Extracted reason (snow, construction, winter, etc.)
+	LastUpdated string            // Timestamp from the page
+}
+
+const roadConditionsURLPattern = "https://roads.dot.ca.gov/roadscell.php?roadnumber=%s"
+
+// ParseRoadConditions fetches and parses the Caltrans road conditions page
+// for the given highway number (e.g., "4" for Highway 4).
+func (p *FeedParser) ParseRoadConditions(ctx context.Context, highwayNumber string) ([]RoadCondition, error) {
+	url := fmt.Sprintf(roadConditionsURLPattern, highwayNumber)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpClient := p.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch road conditions: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP error %d fetching road conditions for highway %s", resp.StatusCode, highwayNumber)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read road conditions response: %w", err)
+	}
+
+	return ParseRoadConditionsHTML(string(body), highwayNumber)
+}
+
+// ParseRoadConditionsHTML parses the HTML content of a road conditions page.
+// Exported for testing.
+func ParseRoadConditionsHTML(html string, highwayNumber string) ([]RoadCondition, error) {
+	var conditions []RoadCondition
+
+	// Extract last updated timestamp
+	lastUpdated := extractLastUpdated(html)
+
+	// Find the section for this highway: <h3>SR {number}</h3>
+	// The content is between this <h3> and the next <hr> or <h3>
+	sectionPattern := regexp.MustCompile(`(?is)<h3>\s*SR\s+` + regexp.QuoteMeta(highwayNumber) + `\s*</h3>(.*?)(?:<hr|<h3)`)
+	sectionMatch := sectionPattern.FindStringSubmatch(html)
+	if sectionMatch == nil {
+		// No conditions found for this highway
+		return nil, nil
+	}
+
+	sectionHTML := sectionMatch[1]
+
+	// Extract area designation from first <strong> tag
+	area := ""
+	areaPattern := regexp.MustCompile(`(?i)<strong>\[([^\]]+)\]</strong>`)
+	if areaMatch := areaPattern.FindStringSubmatch(sectionHTML); len(areaMatch) > 1 {
+		area = strings.TrimSpace(areaMatch[1])
+	}
+
+	// Extract individual conditions from <p> tags
+	pPattern := regexp.MustCompile(`(?is)<p>(.*?)</p>`)
+	pMatches := pPattern.FindAllStringSubmatch(sectionHTML, -1)
+
+	for _, pMatch := range pMatches {
+		if len(pMatch) < 2 {
+			continue
+		}
+
+		// Clean up the text: remove HTML tags, normalize whitespace
+		text := extractTextFromHTML(pMatch[1])
+		if text == "" {
+			continue
+		}
+
+		// Strip area designation prefix if present (e.g., "[IN THE CENTRAL CALIFORNIA AREA]")
+		// The area label and first condition text can appear in the same <p> tag
+		if strings.HasPrefix(text, "[") && strings.Contains(text, "]") {
+			idx := strings.Index(text, "]")
+			text = strings.TrimSpace(text[idx+1:])
+			if text == "" {
+				continue
+			}
+		}
+
+		// Skip informational notices about chain control location updates
+		if strings.Contains(strings.ToLower(text), "please research") ||
+			strings.Contains(strings.ToLower(text), "caltrans is currently working") {
+			continue
+		}
+
+		condType := classifyCondition(text)
+		reason := extractReason(text)
+
+		conditions = append(conditions, RoadCondition{
+			Highway:     highwayNumber,
+			Type:        condType,
+			Description: text,
+			Area:        area,
+			Reason:      reason,
+			LastUpdated: lastUpdated,
+		})
+	}
+
+	return conditions, nil
+}
+
+// classifyCondition determines the type of road condition from its text
+func classifyCondition(text string) RoadConditionType {
+	lower := strings.ToLower(text)
+
+	// Check for closure
+	if strings.Contains(lower, "is closed") || strings.Contains(lower, "are closed") ||
+		strings.HasPrefix(lower, "closed") {
+		return CONDITION_CLOSURE
+	}
+
+	// Check for chain control
+	if strings.Contains(lower, "chains are required") || strings.Contains(lower, "chains required") ||
+		strings.Contains(lower, "chain control") {
+		return CONDITION_CHAIN
+	}
+
+	// Check for restrictions
+	if strings.Contains(lower, "controlled traffic") || strings.Contains(lower, "1-way") ||
+		strings.Contains(lower, "one-way") || strings.Contains(lower, "restricted") ||
+		strings.Contains(lower, "no traffic permitted") {
+		return CONDITION_RESTRICTION
+	}
+
+	return CONDITION_INFO
+}
+
+// extractReason extracts the reason for a condition from its text
+func extractReason(text string) string {
+	lower := strings.ToLower(text)
+
+	reasonPatterns := []struct {
+		pattern string
+		reason  string
+	}{
+		{"due to snow", "snow"},
+		{"due to ice", "ice"},
+		{"due to construction", "construction"},
+		{"due to rock slide", "rockslide"},
+		{"due to mudslide", "mudslide"},
+		{"due to fire", "fire"},
+		{"due to flooding", "flooding"},
+		{"due to accident", "accident"},
+		{"for the winter", "winter_closure"},
+		{"winter closure", "winter_closure"},
+		{"for the season", "seasonal_closure"},
+	}
+
+	for _, rp := range reasonPatterns {
+		if strings.Contains(lower, rp.pattern) {
+			return rp.reason
+		}
+	}
+
+	return ""
+}
+
+// extractLastUpdated extracts the last updated timestamp from the page
+func extractLastUpdated(html string) string {
+	// Pattern: "This highway information is the latest reported as of Tuesday, February 17th, 2026 at 10:25 PM."
+	pattern := regexp.MustCompile(`(?i)latest reported as of\s+\w+,\s+(\w+\s+\d+\w*,\s+\d{4})\s+at\s+(\d{1,2}:\d{2}\s*[APap][Mm])`)
+	match := pattern.FindStringSubmatch(html)
+	if len(match) < 3 {
+		return ""
+	}
+
+	// Clean ordinal suffixes (1st, 2nd, 3rd, 4th, etc.)
+	dateStr := regexp.MustCompile(`(\d+)(st|nd|rd|th)`).ReplaceAllString(match[1], "$1")
+	timeStr := strings.TrimSpace(match[2])
+
+	// Parse: "February 17, 2026" + "10:25 PM"
+	combined := dateStr + " " + timeStr
+	layouts := []string{
+		"January 2, 2006 3:04 PM",
+		"January 2, 2006 3:04PM",
+	}
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, combined); err == nil {
+			return t.Format(time.RFC3339)
+		}
+	}
+
+	return dateStr + " " + timeStr
+}
+
+// MatchConditionToSegment checks if a road condition applies to a specific
+// road segment based on text matching against section names and location keywords.
+// Returns true if the condition should be considered ON_ROUTE for this segment.
+func MatchConditionToSegment(condition RoadCondition, sectionName string, locationKeywords []string) bool {
+	condLower := strings.ToLower(condition.Description)
+
+	// Check section endpoint names (e.g., "Arnold to Bear Valley" → "arnold", "bear valley")
+	sectionTokens := extractSectionLocations(sectionName)
+	for _, token := range sectionTokens {
+		if strings.Contains(condLower, strings.ToLower(token)) {
+			return true
+		}
+	}
+
+	// Check configured location keywords
+	for _, keyword := range locationKeywords {
+		if strings.Contains(condLower, strings.ToLower(keyword)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractSectionLocations extracts location names from a section description
+// e.g., "Arnold to Bear Valley" → ["Arnold", "Bear Valley"]
+// e.g., "Angels Camp to Murphys" → ["Angels Camp", "Murphys"]
+func extractSectionLocations(section string) []string {
+	// Split by common separators: "to", "-", "–"
+	parts := regexp.MustCompile(`(?i)\s+to\s+|\s*[-–]\s*`).Split(section, -1)
+
+	var locations []string
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			locations = append(locations, trimmed)
+		}
+	}
+	return locations
+}

--- a/internal/clients/caltrans/road_conditions_test.go
+++ b/internal/clients/caltrans/road_conditions_test.go
@@ -1,0 +1,252 @@
+package caltrans
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Road Conditions</title></head>
+<body>
+<div id="main_content_1" style="width: 500px;">
+    <div id="main_content_2">
+        <div id="middle_column">
+            <div>
+            <hr>
+<p><em>This highway information is the latest reported as of Tuesday, February 17th, 2026 at 10:25 PM.</em></p>
+<h3>SR 4</h3>
+<p>
+<strong>[IN THE CENTRAL CALIFORNIA AREA]</strong><br />
+Is closed 1 mi east of Camp Connell (Calaveras Co) - Due to snow
+- Motorists are advised to use an alternate route
+</p>
+<p>
+Is closed from 0.6 mi east of Lake Alpine to 7.2 mi west of the
+Jct of SR 89 /Ebbetts Pass/ (Alpine Co) - For the winter - Motorists are
+advised to use an alternate route
+</p>
+<p>
+Chains are required on all vehicles except 4-wheel-drive vehicles with snow
+tires on all 4 wheels from Arnold to the Mt Reba turnoff (Calaveras Co)
+</p>
+<p>
+Please research chain control locations as caltrans is currently working to
+update chain control descriptions for consistency with internet mapping,
+like google maps &amp; mapquest.
+</p>
+<p>
+1-way controlled traffic at the Contra Costa/San Joaquin Co Line
+/at Old River Bridge/ 24 hrs a day 7 days a week thru 1900 hrs on 7/26/26
+- Due to construction
+</p>
+<hr />
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>`
+
+func TestParseRoadConditionsHTML(t *testing.T) {
+	conditions, err := ParseRoadConditionsHTML(testHTML, "4")
+
+	require.NoError(t, err)
+	require.Len(t, conditions, 4, "Should parse 4 conditions (skipping info notice)")
+
+	// Verify first condition: closure at Camp Connell
+	assert.Equal(t, CONDITION_CLOSURE, conditions[0].Type)
+	assert.Contains(t, conditions[0].Description, "Camp Connell")
+	assert.Contains(t, conditions[0].Description, "snow")
+	assert.Equal(t, "snow", conditions[0].Reason)
+	assert.Equal(t, "4", conditions[0].Highway)
+	assert.Equal(t, "IN THE CENTRAL CALIFORNIA AREA", conditions[0].Area)
+
+	// Verify second condition: winter closure at Ebbetts Pass
+	assert.Equal(t, CONDITION_CLOSURE, conditions[1].Type)
+	assert.Contains(t, conditions[1].Description, "Lake Alpine")
+	assert.Contains(t, conditions[1].Description, "Ebbetts Pass")
+	assert.Equal(t, "winter_closure", conditions[1].Reason)
+
+	// Verify third condition: chain control
+	assert.Equal(t, CONDITION_CHAIN, conditions[2].Type)
+	assert.Contains(t, conditions[2].Description, "Arnold")
+	assert.Contains(t, conditions[2].Description, "Mt Reba")
+
+	// Verify fourth condition: restriction
+	assert.Equal(t, CONDITION_RESTRICTION, conditions[3].Type)
+	assert.Contains(t, conditions[3].Description, "1-way controlled traffic")
+	assert.Equal(t, "construction", conditions[3].Reason)
+}
+
+func TestParseRoadConditionsHTML_NoConditions(t *testing.T) {
+	html := `<html><body><h3>SR 99</h3><p>No conditions reported</p><hr /></body></html>`
+	conditions, err := ParseRoadConditionsHTML(html, "4")
+
+	require.NoError(t, err)
+	assert.Nil(t, conditions, "Should return nil when highway not found")
+}
+
+func TestParseRoadConditionsHTML_LastUpdated(t *testing.T) {
+	conditions, err := ParseRoadConditionsHTML(testHTML, "4")
+	require.NoError(t, err)
+	require.NotEmpty(t, conditions)
+
+	assert.Equal(t, "2026-02-17T22:25:00Z", conditions[0].LastUpdated)
+}
+
+func TestClassifyCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected RoadConditionType
+	}{
+		{"Closure - is closed", "Is closed 1 mi east of Camp Connell", CONDITION_CLOSURE},
+		{"Closure - are closed", "Lanes are closed due to construction", CONDITION_CLOSURE},
+		{"Closure - starts with closed", "Closed from mile 10 to mile 20", CONDITION_CLOSURE},
+		{"Chain control", "Chains are required on all vehicles", CONDITION_CHAIN},
+		{"Chain control - required", "Chains required from Arnold", CONDITION_CHAIN},
+		{"Restriction - 1-way", "1-way controlled traffic at the bridge", CONDITION_RESTRICTION},
+		{"Restriction - no traffic", "No traffic permitted after 10pm", CONDITION_RESTRICTION},
+		{"Info", "Road work scheduled for next week", CONDITION_INFO},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyCondition(tt.text)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected string
+	}{
+		{"Snow", "Closed due to snow", "snow"},
+		{"Construction", "Closed due to construction", "construction"},
+		{"Winter", "Closed for the winter", "winter_closure"},
+		{"Rockslide", "Closed due to rock slide", "rockslide"},
+		{"Fire", "Closed due to fire", "fire"},
+		{"No reason", "Road is closed", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractReason(tt.text)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractLastUpdatedFromPage(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "Standard format",
+			html:     `<em>This highway information is the latest reported as of Tuesday, February 17th, 2026 at 10:25 PM.</em>`,
+			expected: "2026-02-17T22:25:00Z",
+		},
+		{
+			name:     "No timestamp",
+			html:     `<em>Some other text</em>`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractLastUpdated(tt.html)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMatchConditionToSegment(t *testing.T) {
+	tests := []struct {
+		name             string
+		condition        RoadCondition
+		sectionName      string
+		locationKeywords []string
+		expected         bool
+	}{
+		{
+			name: "Matches section endpoint - Arnold",
+			condition: RoadCondition{
+				Description: "Chains are required from Arnold to the Mt Reba turnoff",
+			},
+			sectionName:      "Arnold to Bear Valley",
+			locationKeywords: nil,
+			expected:         true,
+		},
+		{
+			name: "Matches location keyword - Camp Connell",
+			condition: RoadCondition{
+				Description: "Is closed 1 mi east of Camp Connell (Calaveras Co)",
+			},
+			sectionName:      "Arnold to Bear Valley",
+			locationKeywords: []string{"Camp Connell", "Dorrington", "White Pines"},
+			expected:         true,
+		},
+		{
+			name: "Matches location keyword - Lake Alpine",
+			condition: RoadCondition{
+				Description: "Is closed from 0.6 mi east of Lake Alpine to 7.2 mi west of the Jct of SR 89",
+			},
+			sectionName:      "Arnold to Bear Valley",
+			locationKeywords: []string{"Camp Connell", "Lake Alpine", "Ebbetts"},
+			expected:         true,
+		},
+		{
+			name: "Does not match different segment",
+			condition: RoadCondition{
+				Description: "Is closed 1 mi east of Camp Connell (Calaveras Co)",
+			},
+			sectionName:      "Angels Camp to Murphys",
+			locationKeywords: []string{"Vallecito", "Douglas Flat"},
+			expected:         false,
+		},
+		{
+			name: "Matches Contra Costa segment for construction",
+			condition: RoadCondition{
+				Description: "1-way controlled traffic at the Contra Costa/San Joaquin Co Line",
+			},
+			sectionName:      "Arnold to Bear Valley",
+			locationKeywords: []string{"Camp Connell"},
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MatchConditionToSegment(tt.condition, tt.sectionName, tt.locationKeywords)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractSectionLocations(t *testing.T) {
+	tests := []struct {
+		name     string
+		section  string
+		expected []string
+	}{
+		{"Standard format", "Arnold to Bear Valley", []string{"Arnold", "Bear Valley"}},
+		{"With dash", "Arnold - Bear Valley", []string{"Arnold", "Bear Valley"}},
+		{"Multi-word locations", "Angels Camp to Murphys", []string{"Angels Camp", "Murphys"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractSectionLocations(tt.section)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,8 +50,9 @@ type RoadsConfig struct {
 
 // CaltransConfig holds Caltrans KML feed settings
 type CaltransConfig struct {
-	LaneClosures CaltransFeedConfig `koanf:"laneClosures"`
-	CHPIncidents CaltransFeedConfig `koanf:"chpIncidents"`
+	LaneClosures   CaltransFeedConfig `koanf:"laneClosures"`
+	CHPIncidents   CaltransFeedConfig `koanf:"chpIncidents"`
+	RoadConditions CaltransFeedConfig `koanf:"roadConditions"`
 }
 
 // CaltransFeedConfig holds individual feed configuration
@@ -62,11 +63,12 @@ type CaltransFeedConfig struct {
 
 // MonitoredRoad represents a road to monitor
 type MonitoredRoad struct {
-	Name        string      `koanf:"name"`
-	Section     string      `koanf:"section"`
-	ID          string      `koanf:"id"`
-	Origin      Coordinates `koanf:"origin"`
-	Destination Coordinates `koanf:"destination"`
+	Name             string      `koanf:"name"`
+	Section          string      `koanf:"section"`
+	ID               string      `koanf:"id"`
+	Origin           Coordinates `koanf:"origin"`
+	Destination      Coordinates `koanf:"destination"`
+	LocationKeywords []string    `koanf:"locationKeywords"`
 }
 
 // WeatherConfig holds weather monitoring configuration

--- a/internal/services/roads.go
+++ b/internal/services/roads.go
@@ -180,10 +180,14 @@ func (s *RoadsService) refreshRoadData(ctx context.Context) ([]*api.Road, error)
 		chainControls = nil
 	}
 
+	// Fetch road conditions from roads.dot.ca.gov for each unique highway
+	roadConditionsByHighway := s.fetchRoadConditions(ctx)
+
 	logging.Infow(ctx, "Retrieved Caltrans incidents for all roads",
 		"lane_closures", len(laneClosures),
 		"chp_incidents", len(chpIncidents),
-		"chain_controls", len(chainControls))
+		"chain_controls", len(chainControls),
+		"road_conditions_highways", len(roadConditionsByHighway))
 
 	// Build routes and collect traffic data for all monitored roads
 	var allRoutes []routing.Route
@@ -229,7 +233,14 @@ func (s *RoadsService) refreshRoadData(ctx context.Context) ([]*api.Road, error)
 		routeAlerts := alertsByRoute[route.ID]
 		traffic := trafficDataMap[monitoredRoad.ID]
 
-		road, err := s.buildRoadFromRouteAndAlerts(ctx, monitoredRoad, route, routeAlerts, traffic, chainControls)
+		// Get road conditions for this road's highway
+		hwNum := extractHighwayNumber(monitoredRoad.Name)
+		var roadConditions []caltrans.RoadCondition
+		if hwNum != "" {
+			roadConditions = roadConditionsByHighway[hwNum]
+		}
+
+		road, err := s.buildRoadFromRouteAndAlerts(ctx, monitoredRoad, route, routeAlerts, traffic, chainControls, roadConditions)
 		if err != nil {
 			logging.Errorw(ctx, "Failed to build road", "road_id", monitoredRoad.ID, "error", err)
 			continue
@@ -376,7 +387,7 @@ func (s *RoadsService) deduplicateAlerts(ctx context.Context, classifications []
 }
 
 // buildRoadFromRouteAndAlerts builds a complete road from route info and classified alerts
-func (s *RoadsService) buildRoadFromRouteAndAlerts(ctx context.Context, monitoredRoad config.MonitoredRoad, route routing.Route, classifiedAlerts []routing.ClassifiedAlert, traffic trafficData, chainControls []caltrans.ChainControlData) (*api.Road, error) {
+func (s *RoadsService) buildRoadFromRouteAndAlerts(ctx context.Context, monitoredRoad config.MonitoredRoad, route routing.Route, classifiedAlerts []routing.ClassifiedAlert, traffic trafficData, chainControls []caltrans.ChainControlData, roadConditions []caltrans.RoadCondition) (*api.Road, error) {
 	// Use the pre-fetched traffic data
 	durationMins := traffic.DurationMins
 	distanceKm := traffic.DistanceKm
@@ -431,6 +442,9 @@ func (s *RoadsService) buildRoadFromRouteAndAlerts(ctx context.Context, monitore
 			}
 		}
 	}
+
+	// Apply road conditions from roads.dot.ca.gov (closures, chain controls)
+	s.applyRoadConditions(ctx, monitoredRoad, roadConditions, &roadStatus, &chainControl, &statusExplanation, &enhancedAlerts)
 
 	// Find chain control info for this route
 	chainControlInfo = s.findChainControlForRoute(ctx, route, chainControls)
@@ -1137,6 +1151,127 @@ func (s *RoadsService) chainControlToString(chainControl api.ChainControlStatus)
 		return "prohibited"
 	default:
 		return "none"
+	}
+}
+
+// fetchRoadConditions fetches road conditions for each unique highway in the monitored roads
+func (s *RoadsService) fetchRoadConditions(ctx context.Context) map[string][]caltrans.RoadCondition {
+	result := make(map[string][]caltrans.RoadCondition)
+
+	// Collect unique highway numbers
+	seen := make(map[string]bool)
+	for _, road := range s.config.Roads.MonitoredRoads {
+		hwNum := extractHighwayNumber(road.Name)
+		if hwNum == "" || seen[hwNum] {
+			continue
+		}
+		seen[hwNum] = true
+
+		conditions, err := s.caltransClient.ParseRoadConditions(ctx, hwNum)
+		if err != nil {
+			logging.Errorw(ctx, "Failed to fetch road conditions",
+				"highway", hwNum, "error", err)
+			continue
+		}
+
+		if len(conditions) > 0 {
+			result[hwNum] = conditions
+			logging.Infow(ctx, "Fetched road conditions",
+				"highway", hwNum,
+				"conditions", len(conditions))
+		}
+	}
+
+	return result
+}
+
+// applyRoadConditions processes road conditions from roads.dot.ca.gov and updates road status
+func (s *RoadsService) applyRoadConditions(ctx context.Context, monitoredRoad config.MonitoredRoad, conditions []caltrans.RoadCondition, roadStatus *api.RoadStatus, chainControl *api.ChainControlStatus, statusExplanation *string, alerts *[]*api.RoadAlert) {
+	if len(conditions) == 0 {
+		return
+	}
+
+	for _, condition := range conditions {
+		isOnRoute := caltrans.MatchConditionToSegment(condition, monitoredRoad.Section, monitoredRoad.LocationKeywords)
+
+		classification := api.AlertClassification_NEARBY
+		if isOnRoute {
+			classification = api.AlertClassification_ON_ROUTE
+		}
+
+		logging.Infow(ctx, "Processing road condition",
+			"road_id", monitoredRoad.ID,
+			"type", condition.Type,
+			"on_route", isOnRoute,
+			"description", condition.Description)
+
+		// Create alert from condition
+		alert := s.buildRoadConditionAlert(condition, classification)
+		*alerts = append(*alerts, alert)
+
+		// Only update road status for ON_ROUTE conditions
+		if !isOnRoute {
+			continue
+		}
+
+		switch condition.Type {
+		case caltrans.CONDITION_CLOSURE:
+			*roadStatus = api.RoadStatus_CLOSED
+			*statusExplanation = condition.Description
+			logging.Infow(ctx, "Road condition: CLOSED",
+				"road_id", monitoredRoad.ID,
+				"reason", condition.Reason,
+				"description", condition.Description)
+
+		case caltrans.CONDITION_CHAIN:
+			if *chainControl != api.ChainControlStatus_REQUIRED {
+				*chainControl = api.ChainControlStatus_REQUIRED
+			}
+			logging.Infow(ctx, "Road condition: chains required",
+				"road_id", monitoredRoad.ID,
+				"description", condition.Description)
+
+		case caltrans.CONDITION_RESTRICTION:
+			if *roadStatus != api.RoadStatus_CLOSED {
+				*roadStatus = api.RoadStatus_RESTRICTED
+				if *statusExplanation == "" {
+					*statusExplanation = condition.Description
+				}
+			}
+		}
+	}
+}
+
+// buildRoadConditionAlert creates a RoadAlert from a road condition
+func (s *RoadsService) buildRoadConditionAlert(condition caltrans.RoadCondition, classification api.AlertClassification) *api.RoadAlert {
+	alertType := api.AlertType_CLOSURE
+	severity := api.AlertSeverity_CRITICAL
+
+	switch condition.Type {
+	case caltrans.CONDITION_CLOSURE:
+		alertType = api.AlertType_CLOSURE
+		severity = api.AlertSeverity_CRITICAL
+	case caltrans.CONDITION_CHAIN:
+		alertType = api.AlertType_WEATHER
+		severity = api.AlertSeverity_WARNING
+	case caltrans.CONDITION_RESTRICTION:
+		alertType = api.AlertType_CLOSURE
+		severity = api.AlertSeverity_WARNING
+	case caltrans.CONDITION_INFO:
+		alertType = api.AlertType_ALERT_TYPE_UNSPECIFIED
+		severity = api.AlertSeverity_INFO
+	}
+
+	return &api.RoadAlert{
+		Type:           alertType,
+		Severity:       severity,
+		Classification: classification,
+		Title:          fmt.Sprintf("SR %s Road Condition", condition.Highway),
+		Description:    condition.Description,
+		Metadata: map[string]string{
+			"source": "roads.dot.ca.gov",
+			"reason": condition.Reason,
+		},
 	}
 }
 

--- a/prefab.yaml
+++ b/prefab.yaml
@@ -48,7 +48,10 @@ roads:
     chpIncidents:
       refreshInterval: "5m"   # More frequent, incidents change quickly
       url: "https://quickmap.dot.ca.gov/data/chp-only.kml"
-    
+    roadConditions:
+      refreshInterval: "10m"  # Caltrans road conditions page (closures, chain controls)
+      url: "https://roads.dot.ca.gov/roadscell.php?roadnumber=%s"
+
   monitoredRoads:
     - name: "Hwy 4"
       section: "Angels Camp to Murphys"
@@ -59,8 +62,9 @@ roads:
       destination:
         latitude: 38.139117
         longitude: -120.456111
+      locationKeywords: ["Vallecito", "Douglas Flat", "Copperopolis"]
     - name: "Hwy 4"
-      section: "Murphys to Arnold"  
+      section: "Murphys to Arnold"
       id: "hwy4-murphys-arnold"
       origin:
         latitude: 38.139117
@@ -68,6 +72,7 @@ roads:
       destination:
         latitude: 38.265006
         longitude: -120.333654
+      locationKeywords: ["Avery", "Hathaway Pines"]
     - name: "Hwy 4"
       section: "Arnold to Bear Valley"
       id: "hwy4-arnold-bearvalley"
@@ -77,6 +82,7 @@ roads:
       destination:
         latitude: 38.461045
         longitude: -120.042368
+      locationKeywords: ["Camp Connell", "Dorrington", "White Pines", "Big Trees", "Ganns", "Tamarack", "Lake Alpine", "Mt Reba", "Ebbetts"]
     # Useful for testing because it is always busy and often has incidents.
     # - name: "101"
     #   section: "SF to Oakland"


### PR DESCRIPTION
The system was only monitoring Caltrans QuickMap KML feeds (lane closures,
CHP incidents, chain controls) which don't include weather/snow closures
or seasonal road closures. Highway 4 was showing only 4-min delays when
the road was actually closed at Camp Connell due to snow.

This adds roads.dot.ca.gov as a new data source that captures full road
closures, chain control requirements, and traffic restrictions that don't
appear in the KML feeds. Conditions are matched to specific road segments
using section names and configurable location keywords.

- Add road conditions HTML parser for roads.dot.ca.gov
- Add LocationKeywords config for matching conditions to road segments
- Integrate road conditions into the refresh pipeline
- Add location keywords for Highway 4 segments (Camp Connell, etc.)

https://claude.ai/code/session_01ShkZhFJiQSkot8Vxu42Tpn